### PR TITLE
Test enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer install ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,11 @@
             "Tamtamchik\\NameCase\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tamtamchik\\NameCase\\Test\\": "tests"
+        }
+    },
     "scripts": {
         "tests": "vendor/bin/phpunit --testdox",
         "demo": "php examples/demo.php"

--- a/tests/NameCaseTest.php
+++ b/tests/NameCaseTest.php
@@ -22,20 +22,6 @@ final class NameCaseTest extends TestCase
         "Yusof bin Ishak",
     ];
 
-    private $macNames = [
-        // Mac exceptions
-        "Machin", "Machlin", "Machar",
-        "Mackle", "Macklin", "Mackie",
-        "Macquarie", "Machado", "Macevicius",
-        "Maciulis", "Macias", "MacMurdo",
-    ];
-
-    private $romanNames = [
-        // Roman numerals
-        "Henry VIII", "Louis III", "Louis XIV",
-        "Charles II", "Fred XLIX",
-    ];
-
     /** Test base UTF-8 support. */
     public function testInternationalization()
     {


### PR DESCRIPTION
# Changed log
- Add `.phpunit.result.cache` file on `.gitignore` file to let this file not be under Git version control.
- Using `install` option on Travis CI build is fine because the `composer.lock` is not under Git version control. It will not cache dependencies during `composer install` command.
- Using the `--prefer-dist` option to download dependency without version control system folders.
- Defining the `"Tamtamchik\\NameCase\\Test\\"` namespace to load test classes automatically.
- Some variables are defined, but not used. I think they should be removed on this test method.