### PR TITLE
Add support for initial names like JJ Abrams and JD Salinger

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Formatter::nameCase("VON STREIT");                       // => von Streit
 Formatter::nameCase("AP LLWYD DAFYDD");                  // => ap Llwyd Dafydd
 Formatter::nameCase("HENRY VIII");                       // => Henry VIII
 Formatter::nameCase("VAN DYKE");                         // => van Dyke
+Formatter::nameCase("JJ ABRAMS");                        // => JJ Abrams
 Formatter::nameCase("PRINCE PHILIP, DUKE OF EDINBURGH"); // => Prince Philip, Duke of Edinburgh
 
 // Or as an instance

--- a/tests/NameCaseTest.php
+++ b/tests/NameCaseTest.php
@@ -36,6 +36,20 @@ final class NameCaseTest extends TestCase
         "Charles II", "Fred XLIX",
     ];
 
+    private $initialNames = [
+        // Two letter initials names should remain capital with and without periods
+        "JJ Abrams", "JD Salinger", "AJ Michalka",
+        "J. F. Kennedy", "J.F. Kennedy",
+        // Except for some specifics
+        "Mr Smith",
+        "Dr Martin Luther King Jr",
+        "St Patrick",
+        "Martin Luther King Sr",
+        // FIXME: These collide with POST_NOMINALS
+        // "Ms Smith",
+        // "Lt Worf",
+    ];
+
     /** Test numbers. */
     public function testNumbersAreUnaffected(): void
     {
@@ -107,8 +121,9 @@ final class NameCaseTest extends TestCase
     /** Test initials */
     public function testInitials(): void
     {
-        $this->assertEquals('J. F. Kennedy', Formatter::nameCase(mb_strtolower('J. F. Kennedy')));
-        $this->assertEquals('J.F. Kennedy', Formatter::nameCase(mb_strtolower('J.F. Kennedy')));
+        foreach ($this->initialNames as $name) {
+            $this->assertEquals($name, Formatter::nameCase(mb_strtolower($name)));
+        }
     }
 
     private $programmers = [


### PR DESCRIPTION
## Updates
Support two-letter names like JJ, JD, AJ, TJ. Most two-letter no-vowel words are initials and should left in uppercase.
There are some exceptions, such as Mr, Ms, Dr. These are explicitly left in mixed case.

## Discussion
This PR aims to fix #16.

I ran into some trouble with `Ms Smith` and `Lt Worf` as exceptions due to those being supported post nominals; extra care may need to be added to ensure a leading space for post nominals? This may also fix "Ed". For now, I left FIXME comments in the code and tried to keep this PR limited in scope.

Happy to tweak my test cases or expand on this PR more, just let me know what you need to get it across the finish line!