### PR TITLE
Update name casing rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring
+          coverage: none
+
+      - name: Validate Composer config
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        run: composer tests

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,8 +1,13 @@
 build:
-  image: default-bionic
+  dependencies:
+    override:
+      - php -r "copy('https://getcomposer.org/download/latest-2.x/composer.phar', 'composer.phar');"
+      - php composer.phar install --no-interaction --prefer-dist
 
   nodes:
-    build:
+    tests:
+      environment:
+        php: 7.3
       tests:
         override:
           - command: XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
@@ -11,6 +16,8 @@ build:
               format: clover
 
     analysis:
+      environment:
+        php: 7.3
       tests:
         override:
           - php-scrutinizer-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All Notable changes to `tamtamchik/namecase` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 3.1.0 - 2026-07-05
+
+### Fixed
+
+- Preserve lowercase HTML entities while name-casing strings (#20).
+- Preserve `Ben` and `Bat` as first names, matching `Lingua::EN::NameCase`.
+- Preserve `binti` and `binte` instead of normalizing both to `bin`.
+- Avoid treating `Ed` in names such as `Ed Oates` as a post-nominal.
+
+### Added
+
+- Post-nominal initials present in `Lingua::EN::NameCase`.
+
 ## 3.0.0 - 2023-01-26
 
 **Breaking Change!** Minimum PHP version is now 7.3.

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ $formatter = new Formatter(['spanish' => true]);
 
 // Or 
 $formatter->setOptions([
-    'lazy' = false, 
+    'lazy' => false,
     'postnominal' => false
 ]);
 
 // Or even
-Formatter::nameCase("VAN DYKE", ['lazy' = false]);
+Formatter::nameCase("VAN DYKE", ['lazy' => false]);
 
 // And for function
-str_name_case("VAN DYKE", ['lazy' = false]);
+str_name_case("VAN DYKE", ['lazy' => false]);
 ```
 
 ## Options

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -464,9 +464,12 @@ class Formatter
             $name
         );
 
+        // Very difficult to write a test in modern environments
+        // @codeCoverageIgnoreStart
         if ( ! is_string($standardEntities)) {
             return $name;
         }
+        // @codeCoverageIgnoreEnd
 
         $commonEntities = mb_ereg_replace_callback(
             '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b',
@@ -476,7 +479,14 @@ class Formatter
             $standardEntities
         );
 
-        return is_string($commonEntities) ? $commonEntities : $standardEntities;
+        // Very difficult to write a test in modern environments
+        // @codeCoverageIgnoreStart
+        if ( ! is_string($commonEntities)) {
+            return $standardEntities;
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $commonEntities;
     }
 
     /**
@@ -494,9 +504,12 @@ class Formatter
             $name
         );
 
+        // Very difficult to write a test in modern environments
+        // @codeCoverageIgnoreStart
         if ( ! is_string($standardEntities)) {
             return $name;
         }
+        // @codeCoverageIgnoreEnd
 
         $commonEntities = mb_ereg_replace(
             '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b',
@@ -504,6 +517,13 @@ class Formatter
             $standardEntities
         );
 
-        return is_string($commonEntities) ? $commonEntities : $standardEntities;
+        // Very difficult to write a test in modern environments
+        // @codeCoverageIgnoreStart
+        if ( ! is_string($commonEntities)) {
+            return $standardEntities;
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $commonEntities;
     }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -61,8 +61,8 @@ class Formatter
     ];
 
     private const HEBREW = [
-        '(\S\s)Ben(?=\s+\w)' => '\1ben',      // Hebrew patronymic particle; keep forename Ben at start.
-        '(\S\s)Bat(?=\s+\w)' => '\1bat',      // Hebrew matronymic particle; keep Bat at start.
+        '(\S\s+)Ben(?=\s+\w)' => '\1ben',     // Hebrew patronymic particle; keep forename Ben at start.
+        '(\S\s+)Bat(?=\s+\w)' => '\1bat',     // Hebrew matronymic particle; keep Bat at start.
     ];
 
     // Spanish conjunctions.
@@ -441,7 +441,7 @@ class Formatter
     {
         $postNominals = array_diff(self::POST_NOMINALS, self::$postNominalsExcluded);
         foreach ($postNominals as $postNominal) {
-            $pattern = '\b' . $postNominal . (mb_strlen($postNominal) <= 2 ? '$' : '\b');
+            $pattern = '\b' . $postNominal . (mb_strlen($postNominal) <= 2 ? '(?=\s*$)' : '\b');
             $name = mb_ereg_replace($pattern, $postNominal, $name, 'ix');
         }
         return $name;

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -71,6 +71,9 @@ class Formatter
     // Roman letters regexp.
     private const ROMAN_REGEX = '\b((?:[Xx]{1,3}|[Xx][Ll]|[Ll][Xx]{0,3})?(?:[Ii]{1,3}|[Ii][VvXx]|[Vv][Ii]{0,3})?)\b';
 
+    private const STANDARD_HTML_ENTITY_REGEX = '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);';
+    private const COMMON_HTML_ENTITY_REGEX = '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b';
+
     // Post nominal values.
     private const POST_NOMINALS = [
         'ACILEx', 'ACSM', 'ADC', 'AEPC', 'AFC', 'AFM', 'AICSM', 'AKC', 'AM', 'ARBRIBA', 'ARCS', 'ARRC', 'ARSM', 'AUH',
@@ -456,37 +459,21 @@ class Formatter
      */
     private static function adjustHTMLEntities(string $name): string
     {
-        $standardEntities = mb_ereg_replace_callback(
-            '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);',
+        $name = mb_ereg_replace_callback(
+            self::STANDARD_HTML_ENTITY_REGEX,
             function ($matches) {
                 return mb_strtolower($matches[0]);
             },
             $name
         );
 
-        // Very difficult to write a test in modern environments
-        // @codeCoverageIgnoreStart
-        if ( ! is_string($standardEntities)) {
-            return $name;
-        }
-        // @codeCoverageIgnoreEnd
-
-        $commonEntities = mb_ereg_replace_callback(
-            '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b',
+        return mb_ereg_replace_callback(
+            self::COMMON_HTML_ENTITY_REGEX,
             function ($matches) {
                 return mb_strtolower($matches[0]);
             },
-            $standardEntities
+            $name
         );
-
-        // Very difficult to write a test in modern environments
-        // @codeCoverageIgnoreStart
-        if ( ! is_string($commonEntities)) {
-            return $standardEntities;
-        }
-        // @codeCoverageIgnoreEnd
-
-        return $commonEntities;
     }
 
     /**
@@ -498,32 +485,16 @@ class Formatter
      */
     private static function stripHTMLEntities(string $name): string
     {
-        $standardEntities = mb_ereg_replace(
-            '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);',
+        $name = mb_ereg_replace(
+            self::STANDARD_HTML_ENTITY_REGEX,
             '',
             $name
         );
 
-        // Very difficult to write a test in modern environments
-        // @codeCoverageIgnoreStart
-        if ( ! is_string($standardEntities)) {
-            return $name;
-        }
-        // @codeCoverageIgnoreEnd
-
-        $commonEntities = mb_ereg_replace(
-            '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b',
+        return mb_ereg_replace(
+            self::COMMON_HTML_ENTITY_REGEX,
             '',
-            $standardEntities
+            $name
         );
-
-        // Very difficult to write a test in modern environments
-        // @codeCoverageIgnoreStart
-        if ( ! is_string($commonEntities)) {
-            return $standardEntities;
-        }
-        // @codeCoverageIgnoreEnd
-
-        return $commonEntities;
     }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -42,7 +42,9 @@ class Formatter
     private const REPLACEMENTS = [
         '\bAl(?=\s+\w)' => 'al',        // al Arabic or forename Al.
         '\bAp\b' => 'ap',        // ap Welsh.
-        '\b(Bin|Binti|Binte)\b' => 'bin',       // bin, binti, binte Arabic.
+        '\bBin\b' => 'bin',       // bin Arabic.
+        '\bBinti\b' => 'binti',       // binti Arabic.
+        '\bBinte\b' => 'binte',       // binte Arabic.
         '\bDell([ae])\b' => 'dell\1',    // della and delle Italian.
         '\bD([aeiou])\b' => 'd\1',       // da, de, di Italian; du French; do Brasil.
         '\bD([ao]s)\b' => 'd\1',       // das, dos Brasileiros.
@@ -59,8 +61,8 @@ class Formatter
     ];
 
     private const HEBREW = [
-        '\bBen(?=\s+\w)' => 'ben', // ben Hebrew or forename Ben.
-        '\bBat(?=\s+\w)' => 'bat', // bat Hebrew or forename Bat.
+        '(\S\s)Ben(?=\s+\w)' => '\1ben', // ben Hebrew or forename Ben.
+        '(\S\s)Bat(?=\s+\w)' => '\1bat', // bat Hebrew or forename Bat.
     ];
 
     // Spanish conjunctions.
@@ -88,14 +90,13 @@ class Formatter
         'ICTTech', 'IDSM', 'IEng', 'IMarEng', 'IOMCPM', 'ISO',
         'J', 'JP', 'JrLog',
         'KBE', 'KC', 'KCB', 'KCIE', 'KCMG', 'KCSI', 'KCVO', 'KG', 'KP', 'KT',
-        'LFHOM', 'LG', 'LJ', 'LLB', 'LLD', 'LLM', 'Log', 'LPE', /* 'LT', - excluded, see initial names */
+        'LFHOM', 'LG', 'LJ', 'LLB', 'LLD', 'LLM', 'Log', 'LPE', 'LT',
         'LVO',
         'MA', 'MAcc', 'MAnth', 'MArch', 'MarEngTech', 'MB', 'MBA', 'MBChB', 'MBE', 'MBEIOM', 'MBiochem', 'MC', 'MCEM',
         'MCGI', 'MCh.', 'MChem', 'MChiro', 'MClinRes', 'MComp', 'MCOptom', 'MCSM', 'MCSP', 'MD', 'MEarthSc',
         'MEng', 'MEnt', 'MEP', 'MFHOM', 'MFin', 'MFPM', 'MGeol', 'MILT', 'MJur', 'MLA', 'MLitt', 'MM', 'MMath',
         'MMathStat', 'MMORSE', 'MMus', 'MOst', 'MP', 'MPAMEd', 'MPharm', 'MPhil', 'MPhys', 'MRCGP', 'MRCOG',
-        'MRCP', 'MRCPath', 'MRCPCHFRCPCH', 'MRCPsych', 'MRCS', 'MRCVS', 'MRes',
-        /* 'MS', - excluded, see initial names */
+        'MRCP', 'MRCPath', 'MRCPCHFRCPCH', 'MRCPsych', 'MRCS', 'MRCVS', 'MRes', 'MS',
         'MSc', 'MScChiro', 'MSci',
         'MSCR', 'MSM', 'MSocSc', 'MSP', 'MSt', 'MSW', 'MSYP', 'MVO',
         'NPQH',
@@ -106,10 +107,13 @@ class Formatter
         'SCHM', 'SCJ', 'SCLD', 'SEN', 'SGM', 'SL', 'SPANSPMH', 'SPCC', 'SPCN', 'SPDN', 'SPHP', 'SPLD', 'SrLog', 'SRN', 'SROT',
         'TD',
         'UD',
-        'V100', 'V200', 'V300', 'VC', 'VD', 'VetMB', 'VN', 'VRD'
+        'V100', 'V200', 'V300', 'VC', 'VD', 'VetMB', 'VN', 'VRD',
+        'AE', 'ARB', 'BVSc', 'BVetMed', 'CMarEng', 'CMarSci', 'CPL', 'CSci', 'CTP', 'FBDO', 'FCOptom',
+        'FFPMRCA', 'FRCA', 'FRCPCH', 'FdA', 'FdSc', 'IOM', 'MEd', 'MPA', 'MRCPCH', 'PC',
+        'QTS', 'RIBA', 'RN1', 'RNA', 'SPAN', 'SPMH'
     ];
 
-    // Excluded post-nominals
+    // Initial names.
     private const INITIAL_NAME_REGEX = '\b(Aj|[bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ]{2})\s';
 
     // Most two-letter words with no vowels should be kept in all caps as initials
@@ -189,6 +193,7 @@ class Formatter
         $name = is_null($name) ? '' : $name;
 
         self::setOptions($options);
+        $name = self::adjustHTMLEntities($name);
 
         // Do not do anything if string is mixed and lazy option is true.
         if ( ! self::canBeProcessed($name)) {
@@ -213,7 +218,7 @@ class Formatter
         $name = self::correctInitialNames($name);
         $name = self::correctLowerCaseWords($name);
 
-        return self::processOptions($name);
+        return self::adjustHTMLEntities(self::processOptions($name));
     }
 
     /**
@@ -241,6 +246,12 @@ class Formatter
      */
     private static function skipMixed(string $name): bool
     {
+        $name = self::stripHTMLEntities($name);
+
+        if ($name == '') {
+            return false;
+        }
+
         $firstLetterLower = $name[0] == mb_strtolower($name[0]);
         $allLowerOrUpper = (mb_strtolower($name) == $name || mb_strtoupper($name) == $name);
 
@@ -430,8 +441,69 @@ class Formatter
     {
         $postNominals = array_diff(self::POST_NOMINALS, self::$postNominalsExcluded);
         foreach ($postNominals as $postNominal) {
-            $name = mb_ereg_replace('\b' . $postNominal . '\b', $postNominal, $name, 'ix');
+            $pattern = '\b' . $postNominal . (mb_strlen($postNominal) <= 2 ? '$' : '\b');
+            $name = mb_ereg_replace($pattern, $postNominal, $name, 'ix');
         }
         return $name;
+    }
+
+    /**
+     * Keep HTML entities lower-case after name capitalization.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private static function adjustHTMLEntities(string $name): string
+    {
+        $standardEntities = mb_ereg_replace_callback(
+            '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);',
+            function ($matches) {
+                return mb_strtolower($matches[0]);
+            },
+            $name
+        );
+
+        if ( ! is_string($standardEntities)) {
+            return $name;
+        }
+
+        $commonEntities = mb_ereg_replace_callback(
+            '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b',
+            function ($matches) {
+                return mb_strtolower($matches[0]);
+            },
+            $standardEntities
+        );
+
+        return is_string($commonEntities) ? $commonEntities : $standardEntities;
+    }
+
+    /**
+     * Strip HTML entities from case checks.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private static function stripHTMLEntities(string $name): string
+    {
+        $standardEntities = mb_ereg_replace(
+            '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);',
+            '',
+            $name
+        );
+
+        if ( ! is_string($standardEntities)) {
+            return $name;
+        }
+
+        $commonEntities = mb_ereg_replace(
+            '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b',
+            '',
+            $standardEntities
+        );
+
+        return is_string($commonEntities) ? $commonEntities : $standardEntities;
     }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -71,9 +71,6 @@ class Formatter
     // Roman letters regexp.
     private const ROMAN_REGEX = '\b((?:[Xx]{1,3}|[Xx][Ll]|[Ll][Xx]{0,3})?(?:[Ii]{1,3}|[Ii][VvXx]|[Vv][Ii]{0,3})?)\b';
 
-    private const STANDARD_HTML_ENTITY_REGEX = '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);';
-    private const COMMON_HTML_ENTITY_REGEX = '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b';
-
     // Post nominal values.
     private const POST_NOMINALS = [
         'ACILEx', 'ACSM', 'ADC', 'AEPC', 'AFC', 'AFM', 'AICSM', 'AKC', 'AM', 'ARBRIBA', 'ARCS', 'ARRC', 'ARSM', 'AUH',
@@ -196,7 +193,7 @@ class Formatter
         $name = is_null($name) ? '' : $name;
 
         self::setOptions($options);
-        $name = self::adjustHTMLEntities($name);
+        $name = HTMLEntities::adjust($name);
 
         // Do not do anything if string is mixed and lazy option is true.
         if ( ! self::canBeProcessed($name)) {
@@ -221,7 +218,7 @@ class Formatter
         $name = self::correctInitialNames($name);
         $name = self::correctLowerCaseWords($name);
 
-        return self::adjustHTMLEntities(self::processOptions($name));
+        return HTMLEntities::adjust(self::processOptions($name));
     }
 
     /**
@@ -249,7 +246,7 @@ class Formatter
      */
     private static function skipMixed(string $name): bool
     {
-        $name = self::stripHTMLEntities($name);
+        $name = HTMLEntities::strip($name);
 
         if ($name == '') {
             return false;
@@ -450,51 +447,4 @@ class Formatter
         return $name;
     }
 
-    /**
-     * Keep HTML entities lower-case after name capitalization.
-     *
-     * @param string $name
-     *
-     * @return string
-     */
-    private static function adjustHTMLEntities(string $name): string
-    {
-        $name = mb_ereg_replace_callback(
-            self::STANDARD_HTML_ENTITY_REGEX,
-            function ($matches) {
-                return mb_strtolower($matches[0]);
-            },
-            $name
-        );
-
-        return mb_ereg_replace_callback(
-            self::COMMON_HTML_ENTITY_REGEX,
-            function ($matches) {
-                return mb_strtolower($matches[0]);
-            },
-            $name
-        );
-    }
-
-    /**
-     * Strip HTML entities from case checks.
-     *
-     * @param string $name
-     *
-     * @return string
-     */
-    private static function stripHTMLEntities(string $name): string
-    {
-        $name = mb_ereg_replace(
-            self::STANDARD_HTML_ENTITY_REGEX,
-            '',
-            $name
-        );
-
-        return mb_ereg_replace(
-            self::COMMON_HTML_ENTITY_REGEX,
-            '',
-            $name
-        );
-    }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -40,29 +40,29 @@ class Formatter
 
     // General replacements.
     private const REPLACEMENTS = [
-        '\bAl(?=\s+\w)' => 'al',        // al Arabic or forename Al.
-        '\bAp\b' => 'ap',        // ap Welsh.
-        '\bBin\b' => 'bin',       // bin Arabic.
-        '\bBinti\b' => 'binti',       // binti Arabic.
-        '\bBinte\b' => 'binte',       // binte Arabic.
-        '\bDell([ae])\b' => 'dell\1',    // della and delle Italian.
-        '\bD([aeiou])\b' => 'd\1',       // da, de, di Italian; du French; do Brasil.
-        '\bD([ao]s)\b' => 'd\1',       // das, dos Brasileiros.
-        '\bDe([lrn])\b' => 'de\1',      // del Italian; der/den Dutch/Flemish.
-        '\bL([eo])\b' => 'l\1',       // lo Italian; le French.
-        '\bTe([rn])\b' => 'te\1',      // ten, ter Dutch/Flemish.
-        '\bVan(?=\s+\w)' => 'van',       // van German or forename Van.
-        '\bVon\b' => 'von',       // von Dutch/Flemish.
+        '\bAl(?=\s+\w)' => 'al',              // Arabic article before another name; ambiguous with forename Al.
+        '\bAp\b' => 'ap',                     // Welsh patronymic particle.
+        '\bBin\b' => 'bin',                   // Arabic/Malay son-of particle.
+        '\bBinti\b' => 'binti',               // Malay daughter-of particle.
+        '\bBinte\b' => 'binte',               // Daughter-of particle.
+        '\bDell([ae])\b' => 'dell\1',         // della and delle Italian.
+        '\bD([aeiou])\b' => 'd\1',            // da, de, di Italian; du French; do Portuguese.
+        '\bD([ao]s)\b' => 'd\1',              // das, dos Portuguese.
+        '\bDe([lrn])\b' => 'de\1',            // del Italian; der/den Dutch/Flemish.
+        '\bL([eo])\b' => 'l\1',               // lo Italian; le French.
+        '\bTe([rn])\b' => 'te\1',             // ten, ter Dutch/Flemish.
+        '\bVan(?=\s+\w)' => 'van',            // Dutch/Flemish particle before another name; ambiguous with forename Van.
+        '\bVon\b' => 'von',                   // German particle.
     ];
 
     private const SPANISH = [
-        '\bEl\b' => 'el',        // el Greek or El Spanish.
-        '\bLa\b' => 'la',        // la French or La Spanish.
+        '\bEl\b' => 'el',                     // Lowercase article by default; Spanish option keeps El.
+        '\bLa\b' => 'la',                     // French article by default; Spanish option keeps La.
     ];
 
     private const HEBREW = [
-        '(\S\s)Ben(?=\s+\w)' => '\1ben', // ben Hebrew or forename Ben.
-        '(\S\s)Bat(?=\s+\w)' => '\1bat', // bat Hebrew or forename Bat.
+        '(\S\s)Ben(?=\s+\w)' => '\1ben',      // Hebrew patronymic particle; keep forename Ben at start.
+        '(\S\s)Bat(?=\s+\w)' => '\1bat',      // Hebrew matronymic particle; keep Bat at start.
     ];
 
     // Spanish conjunctions.

--- a/src/HTMLEntities.php
+++ b/src/HTMLEntities.php
@@ -1,0 +1,58 @@
+<?php namespace Tamtamchik\NameCase;
+
+/**
+ * Class HTMLEntities.
+ */
+class HTMLEntities
+{
+    private const STANDARD_REGEX = '&([A-Za-z][A-Za-z0-9]+|#[0-9]+|#[xX][0-9A-Fa-f]+);';
+    private const COMMON_REGEX = '&([aA][mM][pP]|[lL][tT]|[gG][tT]|[qQ][uU][oO][tT])\b';
+
+    /**
+     * Keep HTML entities lower-case after name capitalization.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function adjust(string $name): string
+    {
+        $name = mb_ereg_replace_callback(
+            self::STANDARD_REGEX,
+            function ($matches) {
+                return mb_strtolower($matches[0]);
+            },
+            $name
+        );
+
+        return mb_ereg_replace_callback(
+            self::COMMON_REGEX,
+            function ($matches) {
+                return mb_strtolower($matches[0]);
+            },
+            $name
+        );
+    }
+
+    /**
+     * Strip HTML entities from case checks.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function strip(string $name): string
+    {
+        $name = mb_ereg_replace(
+            self::STANDARD_REGEX,
+            '',
+            $name
+        );
+
+        return mb_ereg_replace(
+            self::COMMON_REGEX,
+            '',
+            $name
+        );
+    }
+}

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -12,14 +12,16 @@ final class FunctionTest extends TestCase
         "van Dyke", "Van", "ap Llwyd Dafydd",
         "al Fahd", "Al",
         "el Grecco",
-        "ben Gurion", "Ben",
+        "Ben Gurion", "Ben",
+        "Bat Sheva", "Bat",
         "da Vinci",
         "di Caprio", "du Pont", "de Legate",
         "del Crond", "der Sind", "van der Post", "van den Thillart",
         "ter Zanden", "ten Brink",
         "von Trapp", "la Poisson", "le Figaro",
         "Mack Knife", "Dougal MacDonald",
-        "Yusof bin Ishak",
+        "Aharon ben Amram Ha-Kohein",
+        "Yusof bin Ishak", "Fatimah binti Ali", "Aminah binte Musa",
     ];
 
     /** Test function call. */

--- a/tests/HtmlEncodingTest.php
+++ b/tests/HtmlEncodingTest.php
@@ -1,0 +1,51 @@
+<?php namespace Tamtamchik\NameCase\Test;
+
+use PHPUnit\Framework\TestCase;
+use Tamtamchik\NameCase\Formatter;
+use function Tamtamchik\NameCase\str_name_case;
+
+class HtmlEncodingTest extends TestCase
+{
+    private $names = [
+        "Keith & Leo da Vinci",
+        "Keith &amp; Yusof bin Ishak",
+        "Keith &amp; Leo &amp; Ben",
+        "Keith &amp; Leo & ben Gurion",
+        "Keith &amp; Leo &amp; MacMurdo & Paul &quot;Ringo&quot;",
+        "Keith &amp; Leo &amp; John & Paul \"Ringo\"",
+        "&lt;Keith&gt; &amp; Leo",
+        "<Keith> & Leonard",
+        "&#39;Keith&#39; & Leo",
+        "'Keith' &amp; Charles II",
+    ];
+
+    protected function tearDown(): void
+    {
+        Formatter::setOptions(['lazy' => true]);
+    }
+
+    /** Test function call. */
+    public function testCallWorks(): void
+    {
+        foreach ($this->names as $name) {
+            $this->assertEquals($name, str_name_case(mb_strtolower($name)));
+        }
+    }
+
+    public function testEntitiesAreNormalisedBeforeLazySkip(): void
+    {
+        $this->assertEquals('Joe &amp; Bob', str_name_case('Joe &Amp; Bob'));
+        $this->assertEquals('Joe &amp; Bob', str_name_case('Joe &AMP; Bob'));
+    }
+
+    public function testCommonSemicolonlessEntitiesAreNormalised(): void
+    {
+        $this->assertEquals('Joe &amp Bob', str_name_case('joe &amp bob'));
+        $this->assertEquals('Joe &amp Bob', str_name_case('JOE &AMP BOB'));
+    }
+
+    public function testLazyFalseDoesNotBreakEntities(): void
+    {
+        $this->assertEquals('Joe &amp; Bob', Formatter::nameCase('Joe &Amp; Bob', ['lazy' => false]));
+    }
+}

--- a/tests/HtmlEncodingTest.php
+++ b/tests/HtmlEncodingTest.php
@@ -42,6 +42,20 @@ class HtmlEncodingTest extends TestCase
     {
         $this->assertEquals('Joe &amp Bob', str_name_case('joe &amp bob'));
         $this->assertEquals('Joe &amp Bob', str_name_case('JOE &AMP BOB'));
+        $this->assertEquals('Joe &lt Bob &gt Sue', str_name_case('JOE &LT BOB &GT SUE'));
+        $this->assertEquals('Joe &quot Bob', str_name_case('JOE &QUOT BOB'));
+    }
+
+    public function testStandardEntitiesAreNormalised(): void
+    {
+        $this->assertEquals('Joe &nbsp; Bob', str_name_case('JOE &NBSP; BOB'));
+        $this->assertEquals('Joe &#39;Bob&#39;', str_name_case('JOE &#39;BOB&#39;'));
+        $this->assertEquals('Joe &#x27;Bob&#x27;', str_name_case('JOE &#X27;BOB&#X27;'));
+    }
+
+    public function testEntityOnlyStringCanBeProcessed(): void
+    {
+        $this->assertEquals('&amp;', str_name_case('&AMP;'));
     }
 
     public function testLazyFalseDoesNotBreakEntities(): void

--- a/tests/NameCaseTest.php
+++ b/tests/NameCaseTest.php
@@ -13,14 +13,16 @@ final class NameCaseTest extends TestCase
         "van Dyke", "Van", "ap Llwyd Dafydd",
         "al Fahd", "Al",
         "el Grecco",
-        "ben Gurion", "Ben",
+        "Ben Gurion", "Ben",
+        "Bat Sheva", "Bat",
         "da Vinci",
         "di Caprio", "du Pont", "de Legate",
         "del Crond", "der Sind", "van der Post", "van den Thillart",
         "ter Zanden", "ten Brink",
         "von Trapp", "la Poisson", "le Figaro",
         "Mack Knife", "Dougal MacDonald",
-        "Yusof bin Ishak",
+        "Aharon ben Amram Ha-Kohein",
+        "Yusof bin Ishak", "Fatimah binti Ali", "Aminah binte Musa",
     ];
 
     private $macNames = [
@@ -170,7 +172,7 @@ final class NameCaseTest extends TestCase
         "Lou Montulli", "Bram Moolenaar", "David Moon", "Charles H. Moore",
         "Roger Moore", "Mike Muuss", "Patrick Naughton", "Peter Naur",
         "Fredrik Neij", "Graham Nelson", "Peter Norton", "Kristen Nygaard",
-        /* "Ed Oates", Ed is an issue */
+        "Ed Oates",
         "Martin Odersky", "Jarkko Oikarinen", "Oliver Twins",
         "John Ousterhout", "Onel de Guzman", "Larry Page", "Alexey Pajitnov",
         "Seymour Papert", "Tim Paterson", "Markus Persson", "Jeffrey Peterson",

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -59,10 +59,12 @@ class OptionsTest extends TestCase
         Formatter::setOptions(['hebrew' => false]);
         $this->assertEquals('Aharon Ben Amram Ha-Kohein', Formatter::nameCase(mb_strtolower('Aharon BEN Amram Ha-Kohein')));
         $this->assertEquals('Ben Gurion', Formatter::nameCase(mb_strtolower('ben Gurion')));
+        $this->assertEquals('Bat Sheva', Formatter::nameCase(mb_strtolower('Bat Sheva')));
 
         Formatter::setOptions(['hebrew' => true]);
         $this->assertEquals('Aharon ben Amram Ha-Kohein', Formatter::nameCase(mb_strtolower('Aharon BEN Amram Ha-Kohein')));
-        $this->assertEquals('ben Gurion', Formatter::nameCase(mb_strtolower('Ben Gurion')));
+        $this->assertEquals('Ben Gurion', Formatter::nameCase(mb_strtolower('Ben Gurion')));
+        $this->assertEquals('Bat Sheva', Formatter::nameCase(mb_strtolower('Bat Sheva')));
     }
 
     /** Test `postnominal` option */

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -63,6 +63,8 @@ class OptionsTest extends TestCase
 
         Formatter::setOptions(['hebrew' => true]);
         $this->assertEquals('Aharon ben Amram Ha-Kohein', Formatter::nameCase(mb_strtolower('Aharon BEN Amram Ha-Kohein')));
+        $this->assertEquals('Aharon  ben Amram Ha-Kohein', Formatter::nameCase(mb_strtolower('Aharon  BEN Amram Ha-Kohein')));
+        $this->assertEquals("Aharon\tbat Sheva", Formatter::nameCase(mb_strtolower("Aharon\tBat Sheva")));
         $this->assertEquals('Ben Gurion', Formatter::nameCase(mb_strtolower('Ben Gurion')));
         $this->assertEquals('Bat Sheva', Formatter::nameCase(mb_strtolower('Bat Sheva')));
     }

--- a/tests/PostNominalsTest.php
+++ b/tests/PostNominalsTest.php
@@ -15,6 +15,7 @@ class PostNominalsTest extends TestCase
     {
         $this->assertEquals('Ed Oates', Formatter::nameCase('ED OATES'));
         $this->assertEquals('Tam ED', Formatter::nameCase('TAM ED'));
+        $this->assertEquals("Tam ED \n", Formatter::nameCase("TAM ED \n"));
     }
 
     public function testPerlPostNominalInitials(): void

--- a/tests/PostNominalsTest.php
+++ b/tests/PostNominalsTest.php
@@ -11,6 +11,22 @@ class PostNominalsTest extends TestCase
         $this->assertEquals('Adisa Azapagic MBE Freng Frsc Ficheme', Formatter::nameCase('ADISA AZAPAGIC MBE FRENG FRSC FICHEME'));
     }
 
+    public function testAmbiguousInitialsOnlyAtEnd(): void
+    {
+        $this->assertEquals('Ed Oates', Formatter::nameCase('ED OATES'));
+        $this->assertEquals('Tam ED', Formatter::nameCase('TAM ED'));
+    }
+
+    public function testPerlPostNominalInitials(): void
+    {
+        $this->assertEquals('Tam MEd', Formatter::nameCase('TAM MED'));
+        $this->assertEquals('Tam MPA', Formatter::nameCase('TAM MPA'));
+        $this->assertEquals('Tam QTS', Formatter::nameCase('TAM QTS'));
+        $this->assertEquals('Tam RIBA', Formatter::nameCase('TAM RIBA'));
+        $this->assertEquals('Tam FRCA', Formatter::nameCase('TAM FRCA'));
+        $this->assertEquals('Tam FRCPCH', Formatter::nameCase('TAM FRCPCH'));
+    }
+
     public function testExcludeNull(): void
     {
         Formatter::excludePostNominals(null);


### PR DESCRIPTION
## Summary

- Add a GitHub Actions test workflow for pull requests and `master` pushes across PHP 7.3 through 8.5.
- Normalize HTML entities before and after casing, including mixed-case skip detection.
- Align PHP name casing edge cases with Perl behavior for `binti`/`binte`, Hebrew prefixes, post-nominals, and ambiguous initials.

## Why

The 3.1.0 beta fix did not fully cover HTML encoded strings, and the PHP implementation had drifted from the Perl rules in a few edge cases.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml"); puts "yaml ok"'`
- `composer validate --strict && composer install --no-interaction --prefer-dist && composer tests` in a clean `composer:2` Docker copy
- `git diff --check`
