### PR TITLE
Prepare 3.1.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev",
+            "dev-master": "3.1-dev",
             "2.x": "2.x-dev",
             "1.x": "1.x-dev"
         }


### PR DESCRIPTION
Updates the Composer branch alias for the 3.1 development line before tagging 3.1.0.

Checks:
- composer validate --strict
- composer install --no-interaction --prefer-dist
- composer tests