### PR TITLE
Pin GitHub Actions to commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
     name: PHP ${{ matrix.php }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring


### PR DESCRIPTION
Pins GitHub Actions workflow dependencies to full-length commit SHAs instead of mutable tags.

Pinned refs:
- `actions/checkout@v7` -> `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`
- `shivammathur/setup-php@v2` -> `f3e473d116dcccaddc5834248c87452386958240`

This follows GitHub's workflow hardening guidance for immutable action references.

Checks:
- `git diff --check`
